### PR TITLE
Add support for multi-word color names

### DIFF
--- a/color.html
+++ b/color.html
@@ -1,1 +1,1 @@
-<svg onload='with(new webkitSpeechRecognition)start(onresult=e=>bgColor=e.results[0][0].transcript)'>
+<svg onload='with(new webkitSpeechRecognition)start(onresult=e=>bgColor=e.results[0][0].transcript.replace(/\s/g,""))'>


### PR DESCRIPTION
I wasn't very impressed with the speech recognition, until I realized that all the colors that were failing are all multi-word names. Speech recognition hears "dark sea green", not "darkSeaGreen"!

A few bytes for much-wider color support is surely a fair trade. I still fits in a tweet!